### PR TITLE
Use Playwright 16

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -13,8 +13,8 @@ dependencies:
   - pip=22.1.2                        # https://pip.pypa.io/en/stable/news/
   - pip:
     # Define pip packages here -> https://pypi.org/
-    - robotframework-browser==14.4.1  # https://github.com/MarketSquare/robotframework-browser/releases
-    - rpaframework==22.5.3            # https://rpaframework.org/releasenotes.html
+    - robotframework-browser==16.2.0  # https://github.com/MarketSquare/robotframework-browser/releases
+    - rpaframework==23.2.1            # https://rpaframework.org/releasenotes.html
 
 rccPostInstall:
   - rfbrowser init                    # Initialize Playwright

--- a/tasks.robot
+++ b/tasks.robot
@@ -6,4 +6,5 @@ Library             RPA.Browser.Playwright
 
 *** Tasks ***
 Minimal task
-    Open Browser    https://robocorp.com/docs/development-guide/browser/playwright
+    New Browser     headless=${False}  # starts in headless in Control Room
+    New Page    https://robocorp.com/docs/development-guide/browser/playwright


### PR DESCRIPTION
Updates to the latest library version and aligns with the promoted newer Playwright version **16**. Also uses production-ready code instead of the testing keyword `Open Browser`.

CR test [Process](https://cloud.robocorp.com/orgrobocorp/robocorp/processes/b825fb0f-fa09-4551-a402-02244be44c75)